### PR TITLE
Feature/add server dockerfile

### DIFF
--- a/WebApp/server/Dockerfile
+++ b/WebApp/server/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json (if available)
+COPY package*.json ./
+
+# Install dependencies inside the container
+RUN npm install
+
+# Copy the rest of your application code to the container
+COPY . .
+
+# Expose the port that the app will run on (3001)
+EXPOSE 3001
+
+# Run the app using nodemon (use "npm start" to start with nodemon)
+CMD ["npm", "start"]

--- a/WebApp/server/index.js
+++ b/WebApp/server/index.js
@@ -9,3 +9,7 @@ app.use("/getParams", endpoints);
 app.listen(3001, () => {
     console.log("Server running on port 3001");
 });
+
+app.get("/", (req, res) => {
+    res.send("Server running on port 3001");
+});


### PR DESCRIPTION
Fixes #8 

I have added a Dockerfile to the server of the Webapp. To build and run the docker image, use the following commands:

- Build the Docker image:
  `docker build -t servomonitior .`
 
 - Run the Docker container:
   `docker run -p 3001:3001 servomonitior`
   
   I have exposed the port 3001 as the server seems to be running on the same port, let me know if you specifically wanted port 3031